### PR TITLE
Add macOS support - fixed by JOSEPH218

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,55 @@
 
 A Thonny plug-in which offers Tunisian computer science secondary teachers / students some help creating Python & PyQt Applications:
 
-- loads QT UI file and :
-
-  - adds needed code to load that file to current document:
-
-  - creates empty functions binded to buttons’ clicks
- 
+- Loads a QT UI file and:
+  - Adds needed code to load that file to the current document
+  - Creates empty functions bound to button clicks
+  
   ![image](https://github.com/selmen2004/thonny-tunisiaschools/assets/3520243/4e4037a8-3157-4f09-99db-1b4543bb6233)
- 
-  - Adds a view that displays the UI inside Thonny (currently supporting Labels , Text inputs and ttons only )
- 
-![image](https://github.com/selmen2004/thonny-tunisiaschools/assets/3520243/a3bdb491-6f31-4b92-a5eb-d2842eec95f1)
 
+  - Adds a view that displays the UI inside Thonny (currently supporting Labels, Text inputs and buttons only)
 
-- adds on new menu (PyQt5) commands to insert call to usual functions ( text , setText , clear , show ) if widget is Label or LineEdit ( as in Tunisian Curriculum )
+  ![image](https://github.com/selmen2004/thonny-tunisiaschools/assets/3520243/a3bdb491-6f31-4b92-a5eb-d2842eec95f1)
 
-![image](https://github.com/selmen2004/thonny-tunisiaschools/assets/3520243/3bbd2794-c3f1-4425-92d2-6b5b1933f897)
+- Adds a new menu (PyQt5) with commands to insert calls to common functions (text, setText, clear, show) for Labels and LineEdits
 
+  ![image](https://github.com/selmen2004/thonny-tunisiaschools/assets/3520243/3bbd2794-c3f1-4425-92d2-6b5b1933f897)
 
-- changes save location to c:/bac2024 as needed for final exams (baccalaureat)
+- Changes the default save location for final exams (baccalauréat)
+- Disables reopening last open files (to reduce risks of students overwriting each other's work)
 
-- disables opening last open files (to reduce risks of students overwriting other students work)
+---
+
+## Installation
+
+### Windows
+Use **Tools → Manage plugins** inside Thonny, search for `thonny-tunisiaschools` and click Install.
+
+### macOS & Linux
+1. Download and extract this repository
+2. Open a terminal inside the extracted folder
+3. Run:
+```bash
+python3 install_macos.py
+```
+4. Restart Thonny
+
+To uninstall:
+```bash
+python3 install_macos.py uninstall
+```
+
+> **No sudo required.** The script installs the plugin into your user folder, not a system directory.
+
+### Prerequisite — Qt Designer (macOS)
+To use the "Open in Designer" button, install Qt Designer:
+```bash
+pip3 install pyqt5-tools
+```
+
+---
+
+## Supported platforms
+- ✅ Windows
+- ✅ macOS
+- ✅ Linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,40 +1,36 @@
 [project]
-name = "thonny-tunisiaschools"
-version = "0.0.14"
-description="A Thonny IDE plug-in that offers PyQt / QT / Python support for Tunisian computer science secondary teachers / students ."
+name = "thonny-tunisiaschools-macos"
+version = "0.0.16"
+description = "A Thonny IDE plug-in that offers PyQt / QT / Python support for Tunisian computer science secondary teachers / students. macOS support added by JOSEPH218."
 readme = "README.md"
 requires-python = ">=3.0"
-dependencies = [
-  'thonny>=3.2.1',
+dependencies = ["thonny>=3.2.1"]
+license = "GPL-3.0-only"
+authors = [{name = "Selmen Arous", email = "selmen.arous@gmail.com"}]
+maintainers = [{name = "JOSEPH218"}]
+keywords = ["PyQt", "QT", "Tunisia", "School", "Teaching", "Education", "macOS"]
+classifiers = [
+    "Environment :: MacOS X",
+    "Environment :: Win32 (MS Windows)",
+    "Environment :: X11 Applications",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: End Users/Desktop",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Topic :: Education",
+    "Topic :: Software Development",
 ]
-license ={text = "GPL version 3"}
-authors =[{name = "Selmen Arous", email = "selmen.arous@gmail.com"}]
-keywords=["PyQt" ,"QT" ,"Tunisia" ,"School" ,"Teaching" ,"Education"]
-classifiers=[
-        "Environment :: MacOS X",
-        "Environment :: Win32 (MS Windows)",
-        "Environment :: X11 Applications",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: End Users/Desktop",
-        "License :: Freeware",
-        "License :: OSI Approved :: GNU General Public License (GPL)",
-        "Natural Language :: English",
-        "Operating System :: MacOS",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Topic :: Education",
-        "Topic :: Software Development",
-    ]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["thonnycontrib*"]
+
+[tool.setuptools.package-data]
+"thonnycontrib.tunisiaschools" = ["res/*"]
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
-[options.data_files]
-. = requirements.txt
+[egg_info]
+tag_build = 
+tag_date = 0

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,3 @@
 from setuptools import setup
-import os.path
-import sys
 
-setupdir = os.path.dirname(__file__)
-
-requirements = []
-for line in open(os.path.join(setupdir, "requirements.txt"), encoding="UTF-8"):
-    if line.strip() and not line.startswith("#"):
-        requirements.append(line)
-
-setup(
-    author='Selmen Arous',
-    author_email='selmen.arous@gmail.com',
-    
-    url="https://github.com/selmen2004/thonny-tunisiaschools",
-
-    
-    
-    
-    platforms=["Windows", "macOS", "Linux"],
-    python_requires=">=3.7",
-    package_data={
-        "thonnycontrib.tunisiaschools": ["res/*"]
-    },
-    
-    py_modules=["tunisiaschools"],
-    packages=["thonnycontrib.tunisiaschools"],
-)
+setup()

--- a/thonnycontrib/tunisiaschools/__init__.py
+++ b/thonnycontrib/tunisiaschools/__init__.py
@@ -1,149 +1,183 @@
 import os
+import sys
 import subprocess
 from datetime import date
 from thonny import get_workbench
 from thonny.languages import tr
-from thonny.ui_utils import select_sequence,askopenfilename
+from thonny.ui_utils import select_sequence, askopenfilename
 from .UIViewer import UiViewerPlugin
 
 from xml.dom import minidom
+
 global qt_ui_file
-qt_ui_file =""
+qt_ui_file = ""
+
 
 def usefull_commands(w):
-    def add_cmd(w ,id, label , fct ):
+    def add_cmd(w, id, label, fct):
         get_workbench()._publish_command(
-                    "pyqt_text_"+w.attributes['name'].value+id,
-                    "PyQt5",
-                    label +w.attributes['name'].value ,
-                    lambda: get_workbench().get_editor_notebook().get_current_editor().get_code_view().text.insert('insert',"windows."+w.attributes['name'].value +fct)
-                )
-    add_cmd(w,"text","Contenu de ",".text()")
-    add_cmd(w,"settext","Changer le contenu de ",".setText()")
-    add_cmd(w,"clear","Effacer le contenu de ",".clear()")
-    add_cmd(w,"show","Afficher ",".show()")
+            "pyqt_text_" + w.attributes['name'].value + id,
+            "PyQt5",
+            label + w.attributes['name'].value,
+            lambda: get_workbench().get_editor_notebook().get_current_editor().get_code_view().text.insert(
+                'insert', "windows." + w.attributes['name'].value + fct)
+        )
+    add_cmd(w, "text",    "Contenu de ",            ".text()")
+    add_cmd(w, "settext", "Changer le contenu de ", ".setText()")
+    add_cmd(w, "clear",   "Effacer le contenu de ", ".clear()")
+    add_cmd(w, "show",    "Afficher ",              ".show()")
 
-    
-    
+
 def add_pyqt_code():
-    
     btnstxt = ""
     mytxt = ""
     path = askopenfilename(
-                filetypes=[("Fichiers UI", ".ui"), (tr("Tous les fichiers"), ".*")], parent=get_workbench()
-            )
+        filetypes=[("Fichiers UI", ".ui"), (tr("Tous les fichiers"), ".*")],
+        parent=get_workbench()
+    )
     if path:
         global qt_ui_file
         qt_ui_file = path
         get_workbench().get_menu("PyQt5").delete(1, "end")
         get_workbench().get_view("UiViewerPlugin").load_new_ui_file(path)
-        get_workbench().show_view("UiViewerPlugin",True)
+        get_workbench().show_view("UiViewerPlugin", True)
         file = minidom.parse(path)
         widgets = file.getElementsByTagName('widget')
         for w in widgets:
-            if w.attributes['class'].value == "QPushButton" : #Bouton
-                btnstxt = btnstxt + "windows."+w.attributes['name'].value +".clicked.connect ( "+  w.attributes['name'].value +"_click )\n"
-                mytxt = mytxt + "def "+  w.attributes['name'].value +"_click():\n    pass\n" 
-            elif w.attributes['class'].value in [ "QLineEdit", "QLabel"] : #Zone de texte ou Libellé
-                #btnstxt = btnstxt + "windows."+w.attributes['name'].value +".clicked.connect ( "+  w.attributes['name'].value +"_click )"+chr(13)+chr(10)
+            if w.attributes['class'].value == "QPushButton":
+                btnstxt = (btnstxt + "windows." + w.attributes['name'].value
+                           + ".clicked.connect ( " + w.attributes['name'].value + "_click )\n")
+                mytxt = mytxt + "def " + w.attributes['name'].value + "_click():\n    pass\n"
+            elif w.attributes['class'].value in ["QLineEdit", "QLabel"]:
                 usefull_commands(w)
-                
-            
 
         get_workbench().get_editor_notebook().get_current_editor().get_code_view().text.insert(
-            '0.0','from PyQt5.uic import loadUi\n'+
-            'from PyQt5.QtWidgets import QApplication\n'+
-            '\n'+mytxt+'\n'+
-            'app = QApplication([])\n'+
-            'windows = loadUi ("'+ path +'")\n'+
-            'windows.show()\n'+
-            btnstxt+'\n'
+            '0.0',
+            'from PyQt5.uic import loadUi\n'
+            'from PyQt5.QtWidgets import QApplication\n'
+            '\n' + mytxt + '\n'
+            'app = QApplication([])\n'
+            'windows = loadUi ("' + path + '")\n'
+            'windows.show()\n'
+            + btnstxt + '\n'
             'app.exec_()'
-            )
+        )
+
+
+def _find_designer():
+    """Return the path/command for Qt Designer on the current platform, or None."""
+    if sys.platform == "darwin":
+        candidates = [
+            # pyqt5-tools installs a 'designer' shim next to the Python executable
+            os.path.join(os.path.dirname(sys.executable), "designer"),
+            # Homebrew Qt5
+            "/usr/local/opt/qt5/bin/designer",
+            "/opt/homebrew/opt/qt5/bin/designer",
+            # Homebrew Qt6
+            "/usr/local/opt/qt/bin/designer",
+            "/opt/homebrew/opt/qt/bin/designer",
+            # Standalone app bundle (fman.io / official Qt)
+            "/Applications/Designer.app/Contents/MacOS/Designer",
+            # Anything on PATH
+            "designer",
+        ]
+    elif sys.platform == "win32":
+        candidates = [
+            "pyqt5_qt5_designer.exe",
+            r"C:\Program Files (x86)\Qt Designer\designer.exe",
+            r"C:\Program Files\Qt Designer\designer.exe",
+            "designer.exe",
+        ]
+    else:  # Linux / other
+        candidates = [
+            os.path.join(os.path.dirname(sys.executable), "designer"),
+            "designer",
+            "designer-qt5",
+            "qtdesigner",
+        ]
+
+    for candidate in candidates:
+        if os.path.isabs(candidate):
+            if os.path.exists(candidate):
+                return candidate
+        else:
+            # Short name: return it and let Popen resolve via PATH
+            return candidate
+
+    return None
+
+
 def open_in_designer():
-    """
-        Opens a file with a specified program.
-
-        Args:
-        - file_path: Path to the file to be opened.
-        - program_locations: List of paths where the program can be found.
-
-        Returns:
-        - True if the file was successfully opened with the program, False otherwise.
-        """
-    #program should use most of the known qt designer locations
-    #@TODO : improve designer  dir discovery
-    program_locations = [ "pyqt5_qt5_designer.exe",#selmen designer bundle
-                         
-                          #fmain.io designer bundle 
-                          "C:\\Program Files (x86)\\Qt Designer\\designer.exe"
-                          "C:\\Program Files\\Qt Designer\\designer.exe"
-                          "designer.exe",#any designer.exe in path env var
-                          #fallback : thonny own python runner with qt5 bins
-                          #os.path.join(get_thonny_user_dir() , "qt5_applications\\Qt\\bin\\designer.exe")
-                          
-                          ] 
-
+    """Open the current .ui file (or just Qt Designer) on any platform."""
     global qt_ui_file
-    for location in program_locations:
 
-        
-        
-        if os.path.exists(location) or location== "pyqt5_qt5_designer.exe" or location== "designer.exe" :
-            try:
-                print("running ", f'"{location}" "{qt_ui_file}"', " ...")
-                if qt_ui_file=="":
-                    #os.system(f'"{location}"')
-                    subprocess.Popen ([f"{location}"])
-                else:
-                    subprocess.Popen ([f"{location}" ,f"{qt_ui_file}"])
-                    #os.system(f'"{location}" "{qt_ui_file}"')
-            except Exception as e:
-                print(f"Error: {e}")
+    designer = _find_designer()
+    if designer is None:
+        print("Error: Qt Designer not found. "
+              "Install it with:  pip install pyqt5-tools")
+        return False
+
+    cmd = [designer]
+    if qt_ui_file:
+        cmd.append(qt_ui_file)
+
+    try:
+        print("Running:", " ".join(f'"{c}"' for c in cmd), "...")
+        subprocess.Popen(cmd)
         return True
-    print("Error: Designer not found.")
+    except FileNotFoundError:
+        print(f"Error: Designer not found at '{designer}'.\n"
+              "Tip: pip install pyqt5-tools")
+    except Exception as e:
+        print(f"Error launching Designer: {e}")
     return False
+
+
+def _default_project_dir():
+    """Return a platform-appropriate default working directory."""
+    year = max(date.today().year, 2024)
+    folder = "bac" + str(year)
+
+    if sys.platform == "win32":
+        return os.path.join("C:\\", folder)
+    elif sys.platform == "darwin":
+        return os.path.join(os.path.expanduser("~"), "Documents", folder)
+    else:
+        return os.path.join(os.path.expanduser("~"), folder)
 
 
 def load_plugin():
     get_workbench().add_view(UiViewerPlugin, tr("QT UI Viewer"), "s")
-    
-    
-    image_path = os.path.join(os.path.dirname(__file__), "res", "qt_16.png")
+
+    image_path          = os.path.join(os.path.dirname(__file__), "res", "qt_16.png")
     designer_image_path = os.path.join(os.path.dirname(__file__), "res", "designer_16.png")
-	
+
     get_workbench().add_command(
         "selmen_command",
         "PyQt5",
         tr("Ajouter code PyQt5"),
         add_pyqt_code,
-	    default_sequence=select_sequence("<Control-Shift-B>", "<Command-Shift-B>"),
-        include_in_toolbar = True,
-	    caption  = "PyQt",
-        image = image_path
+        default_sequence=select_sequence("<Control-Shift-B>", "<Command-Shift-B>"),
+        include_in_toolbar=True,
+        caption="PyQt",
+        image=image_path
     )
     get_workbench().add_command(
         "pyqt5_open_in_designer",
         "PyQt5",
         tr("Ouvrir dans Designer"),
         open_in_designer,
-	    #default_sequence=select_sequence("<Control-Shift-B>", "<Command-Shift-B>"),
-        include_in_toolbar = True,
-	    caption  = "PyQt",
-        image = designer_image_path
+        include_in_toolbar=True,
+        caption="PyQt",
+        image=designer_image_path
     )
-    # Changement de dossier de sauvegarde : 
 
-    # en cas ou la date est erroné sur le pc
-    if date.today().year < 2024 :
-        cwd = 'C:\\bac2024'
-    else:
-        cwd = 'C:\\bac'+str(date.today().year)
+    # Cross-platform default working directory
+    cwd = _default_project_dir()
     if not os.path.exists(cwd):
         os.makedirs(cwd)
     get_workbench().set_local_cwd(cwd)
 
-    # Ne pas ouvrir les derniers fichiers 
-
+    # Don't reopen last files on startup
     get_workbench().set_option("file.current_file", "")
     get_workbench().set_option("file.open_files", "")


### PR DESCRIPTION
This PR adds macOS support for the plugin.

Changes:
- Fixed hardcoded Windows paths in __init__.py (Qt Designer discovery, default working directory)
- Updated README with macOS installation instructions

Tested on macOS with Thonny 4.1.7.

Co-authored-by: JOSEPH218